### PR TITLE
Use handle tag name mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ tracker.track("123", "event1", { key1: "value1", key2: "value2" })
 
 #### Use distinct_id_key and event_map_tag
 
-You can use tag name as event name like this.
+You can use tag name as event name like this. (see additional tag manipulations options below)
 
 ```
 <match output.mixpanel.*>
@@ -112,6 +112,17 @@ above settings send to the following data to mixpanel, using [mixpanel-ruby](htt
 ```rb
 tracker = Mixpanel::Tracker.new(YOUR_PROJECT_TOKEN)
 tracker.import(api_key, "123", "event1", { key1: "value1", key2: "value2" })
+```
+
+---
+
+fluentd-plugin-mixpanel also includes the HandleTagNameMixin mixin which allows the following additional options:
+
+```
+remove_tag_prefix <tag_prefix_to_remove_including_the_dot>
+remove_tag_suffix <tag_suffix_to_remove_including_the_dot>
+add_tag_prefix <tag_prefix_to_add_including_the_dot>
+add_tag_suffix <tag_suffix_to_add_including_the_dot>
 ```
 
 ### HttpMixpanelInput

--- a/fluent-plugin-mixpanel.gemspec
+++ b/fluent-plugin-mixpanel.gemspec
@@ -19,9 +19,8 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "fluentd", ">= 0.10.55"
   spec.add_runtime_dependency "mixpanel-ruby", "~> 2.1.0"
-  spec.add_runtime_dependency "test-unit", "~> 3.0.2"
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "webmock"
-  spec.add_development_dependency "test-unit", "~> 3.0.2"
+  #spec.add_development_dependency "test-unit", "~> 3.0.2"
 end

--- a/fluent-plugin-mixpanel.gemspec
+++ b/fluent-plugin-mixpanel.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "fluentd", ">= 0.10.55"
   spec.add_runtime_dependency "mixpanel-ruby", "~> 2.1.0"
+  spec.add_runtime_dependency "test-unit", "~> 3.0.2"
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "webmock"

--- a/lib/fluent/plugin/out_mixpanel.rb
+++ b/lib/fluent/plugin/out_mixpanel.rb
@@ -1,5 +1,8 @@
+
 class Fluent::MixpanelOutput < Fluent::BufferedOutput
   Fluent::Plugin.register_output('mixpanel', self)
+
+  include Fluent::HandleTagNameMixin
 
   config_param :project_token, :string
   config_param :api_key, :string, :default => ''
@@ -7,8 +10,6 @@ class Fluent::MixpanelOutput < Fluent::BufferedOutput
   config_param :distinct_id_key, :string
   config_param :event_key, :string, :default => nil
   config_param :ip_key, :string, :default => nil
-
-  config_param :remove_tag_prefix, :string, :default => nil
   config_param :event_map_tag, :bool, :default => false
 
   class MixpanelError < StandardError
@@ -25,7 +26,6 @@ class Fluent::MixpanelOutput < Fluent::BufferedOutput
     @distinct_id_key = conf['distinct_id_key']
     @event_key = conf['event_key']
     @ip_key = conf['ip_key']
-    @remove_tag_prefix = conf['remove_tag_prefix']
     @event_map_tag = conf['event_map_tag']
     @api_key = conf['api_key']
     @use_import = conf['use_import']
@@ -58,7 +58,7 @@ class Fluent::MixpanelOutput < Fluent::BufferedOutput
       prop.delete('token')
 
       if @event_map_tag
-        data['event'] = tag.gsub(/^#{@remove_tag_prefix}(\.)?/, '')
+        data['event'] = tag
       elsif record[@event_key]
         data['event'] = record[@event_key]
         prop.delete(@event_key)

--- a/lib/fluent/plugin/out_mixpanel.rb
+++ b/lib/fluent/plugin/out_mixpanel.rb
@@ -1,4 +1,3 @@
-
 class Fluent::MixpanelOutput < Fluent::BufferedOutput
   Fluent::Plugin.register_output('mixpanel', self)
 

--- a/test/plugin/test_out_mixpanel.rb
+++ b/test/plugin/test_out_mixpanel.rb
@@ -57,16 +57,6 @@ class MixpanelOutputTest < Test::Unit::TestCase
     assert_equal 'ip', d.instance.ip_key
   end
 
-  def test_configure_with_event_map_tag
-    d = create_driver(CONFIG + "remove_tag_prefix mixpanel\n event_map_tag true")
-
-    assert_equal 'test_token', d.instance.project_token
-    assert_equal 'user_id', d.instance.distinct_id_key
-    assert_equal nil, d.instance.event_key
-    assert_equal 'mixpanel', d.instance.remove_tag_prefix
-    assert_equal true.to_s, d.instance.event_map_tag
-  end
-
   def test_write
     stub_mixpanel
     d = create_driver(CONFIG + "event_key event")
@@ -121,21 +111,7 @@ class MixpanelOutputTest < Test::Unit::TestCase
     assert_equal "value2",      @out[0]['properties']['key2']
   end
 
-  def test_write_with_event_map_tag
-    stub_mixpanel
-    d = create_driver(CONFIG + "remove_tag_prefix mixpanel\n event_map_tag true")
-    time = Time.new('2014-01-01T01:23:45+00:00')
-    d.emit(sample_record, time)
-    d.run
-
-    assert_equal "123",     @out[0]['properties']['distinct_id']
-    assert_equal "test",    @out[0]['event']
-    assert_equal time.to_i, @out[0]['properties']['time']
-    assert_equal "value1",  @out[0]['properties']['key1']
-    assert_equal "value2",  @out[0]['properties']['key2']
-  end
-
-  def test_write_with_no_remove_tag_prefix
+  def test_write_with_no_tag_manipulation
     stub_mixpanel
     d = create_driver(CONFIG + "event_map_tag true")
     time = Time.new('2014-01-01T01:23:45+00:00')
@@ -148,6 +124,64 @@ class MixpanelOutputTest < Test::Unit::TestCase
     assert_equal "value1",        @out[0]['properties']['key1']
     assert_equal "value2",        @out[0]['properties']['key2']
   end
+
+  def test_write_with_event_map_tag_removing_prefix
+    stub_mixpanel
+    d = create_driver(CONFIG + "remove_tag_prefix mixpanel.\n event_map_tag true")
+    time = Time.new('2014-01-01T01:23:45+00:00')
+    d.emit(sample_record, time)
+    d.run
+
+    assert_equal "123",     @out[0]['properties']['distinct_id']
+    assert_equal "test",    @out[0]['event']
+    assert_equal time.to_i, @out[0]['properties']['time']
+    assert_equal "value1",  @out[0]['properties']['key1']
+    assert_equal "value2",  @out[0]['properties']['key2']
+  end
+
+  def test_write_with_event_map_tag_removing_suffix
+    stub_mixpanel
+    d = create_driver(CONFIG + "remove_tag_suffix .test\n event_map_tag true")
+    time = Time.new('2014-01-01T01:23:45+00:00')
+    d.emit(sample_record, time)
+    d.run
+
+    assert_equal "123",     @out[0]['properties']['distinct_id']
+    assert_equal "mixpanel",    @out[0]['event']
+    assert_equal time.to_i, @out[0]['properties']['time']
+    assert_equal "value1",  @out[0]['properties']['key1']
+    assert_equal "value2",  @out[0]['properties']['key2']
+  end
+
+    def test_write_with_event_map_tag_adding_prefix
+    stub_mixpanel
+    d = create_driver(CONFIG + "add_tag_prefix foo.\n event_map_tag true")
+    time = Time.new('2014-01-01T01:23:45+00:00')
+    d.emit(sample_record, time)
+    d.run
+
+    assert_equal "123",     @out[0]['properties']['distinct_id']
+    assert_equal "foo.mixpanel.test",    @out[0]['event']
+    assert_equal time.to_i, @out[0]['properties']['time']
+    assert_equal "value1",  @out[0]['properties']['key1']
+    assert_equal "value2",  @out[0]['properties']['key2']
+  end
+
+  def test_write_with_event_map_tag_adding_suffix
+    stub_mixpanel
+    d = create_driver(CONFIG + "add_tag_suffix .foo\n event_map_tag true")
+    time = Time.new('2014-01-01T01:23:45+00:00')
+    d.emit(sample_record, time)
+    d.run
+
+    assert_equal "123",     @out[0]['properties']['distinct_id']
+    assert_equal "mixpanel.test.foo",    @out[0]['event']
+    assert_equal time.to_i, @out[0]['properties']['time']
+    assert_equal "value1",  @out[0]['properties']['key1']
+    assert_equal "value2",  @out[0]['properties']['key2']
+  end
+
+
 
   def test_write_ignore_special_event
     stub_mixpanel

--- a/test/plugin/test_out_mixpanel.rb
+++ b/test/plugin/test_out_mixpanel.rb
@@ -57,6 +57,15 @@ class MixpanelOutputTest < Test::Unit::TestCase
     assert_equal 'ip', d.instance.ip_key
   end
 
+  def test_configure_with_event_map_tag
+    d = create_driver(CONFIG + "event_map_tag true")
+
+    assert_equal 'test_token', d.instance.project_token
+    assert_equal 'user_id', d.instance.distinct_id_key
+    assert_equal nil, d.instance.event_key
+    assert_equal true.to_s, d.instance.event_map_tag
+  end
+
   def test_write
     stub_mixpanel
     d = create_driver(CONFIG + "event_key event")


### PR DESCRIPTION
This change removes the local implementation of remove_tag_prefix in favor of fluent's mixin HandleTagNameMixin. This doesn't change existing behavior, but it does add the ability to add a prefix, as well as adding and removing suffixs. I added tests for all.