### PR TITLE
Use handle tag name mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ tracker.track("123", "event1", { key1: "value1", key2: "value2" })
 
 #### Use distinct_id_key and event_map_tag
 
-You can use tag name as event name like this.
+You can use tag name as event name like this. (see additional tag manipulations options below)
 
 ```
 <match output.mixpanel.*>
@@ -112,6 +112,17 @@ above settings send to the following data to mixpanel, using [mixpanel-ruby](htt
 ```rb
 tracker = Mixpanel::Tracker.new(YOUR_PROJECT_TOKEN)
 tracker.import(api_key, "123", "event1", { key1: "value1", key2: "value2" })
+```
+
+---
+
+fluentd-plugin-mixpanel also includes the HandleTagNameMixin mixin which allows the following additional options:
+
+```
+remove_tag_prefix <tag_prefix_to_remove_including_the_dot>
+remove_tag_suffix <tag_suffix_to_remove_including_the_dot>
+add_tag_prefix <tag_prefix_to_add_including_the_dot>
+add_tag_suffix <tag_suffix_to_add_including_the_dot>
 ```
 
 ### HttpMixpanelInput

--- a/README.md
+++ b/README.md
@@ -62,12 +62,21 @@ tracker.track("123", "event1", { key1: "value1", key2: "value2" })
 
 You can use tag name as event name like this. (see additional tag manipulations options below)
 
+##PLEASE NOTE (breaking api change in a future release)
+
+The api for remove_tag_prefix will be changing in a future release. There is currently a boolean option,
+use_legacy_prefix_behavior, which will ensure legacy behavior is maintained until that time. Eventually this option will go away
+as well and the new behavior will be the only way. The difference is pretty simple, the '.' in the prefix needs to be specified.
+This change allows this plugin to use Fluet's mixin and unifies syntax across plugins. Currently, use_legacy_prefix_behavior
+defaults to true, which will work either way, but eventually you will need to specify the '.' in your prefix. Again, use_legacy_prefix_behavior simply removes any '.' along with the specified prefix and will behave properly even after you change your configs
+to be current as seen below. You do not need to set this option.
+
 ```
 <match output.mixpanel.*>
   type mixpanel
   project_token YOUR_PROJECT_TOKEN
   distinct_id_key user_id
-  remove_tag_prefix output.mixpanel
+  remove_tag_prefix output.mixpanel.
   event_map_tag true
 </match>
 ```
@@ -94,7 +103,7 @@ You can use tag name as event name like this.
   type mixpanel
   project_token YOUR_PROJECT_TOKEN
   distinct_id_key user_id
-  remove_tag_prefix output.mixpanel
+  remove_tag_prefix output.mixpanel.
   event_map_tag true
   use_import true
   api_key YOUR_API_KEY

--- a/lib/fluent/plugin/out_mixpanel.rb
+++ b/lib/fluent/plugin/out_mixpanel.rb
@@ -1,5 +1,8 @@
+
 class Fluent::MixpanelOutput < Fluent::BufferedOutput
   Fluent::Plugin.register_output('mixpanel', self)
+
+  include Fluent::HandleTagNameMixin
 
   config_param :project_token, :string
   config_param :api_key, :string, :default => ''
@@ -7,8 +10,6 @@ class Fluent::MixpanelOutput < Fluent::BufferedOutput
   config_param :distinct_id_key, :string
   config_param :event_key, :string, :default => nil
   config_param :ip_key, :string, :default => nil
-
-  config_param :remove_tag_prefix, :string, :default => nil
   config_param :event_map_tag, :bool, :default => false
 
   class MixpanelError < StandardError
@@ -25,7 +26,6 @@ class Fluent::MixpanelOutput < Fluent::BufferedOutput
     @distinct_id_key = conf['distinct_id_key']
     @event_key = conf['event_key']
     @ip_key = conf['ip_key']
-    @remove_tag_prefix = conf['remove_tag_prefix']
     @event_map_tag = conf['event_map_tag']
     @api_key = conf['api_key']
     @use_import = conf['use_import']
@@ -58,7 +58,7 @@ class Fluent::MixpanelOutput < Fluent::BufferedOutput
       prop.delete('token')
 
       if @event_map_tag
-        data['event'] = tag.gsub(/^#{@remove_tag_prefix}(\.)?/, '')
+        data['event'] = tag
       elsif record[@event_key]
         data['event'] = record[@event_key]
         prop.delete(@event_key)

--- a/lib/fluent/plugin/out_mixpanel.rb
+++ b/lib/fluent/plugin/out_mixpanel.rb
@@ -11,6 +11,8 @@ class Fluent::MixpanelOutput < Fluent::BufferedOutput
   config_param :event_key, :string, :default => nil
   config_param :ip_key, :string, :default => nil
   config_param :event_map_tag, :bool, :default => false
+  #NOTE: This will be removed in a future release. Please specify the '.' on any prefix
+  config_param :use_legacy_prefix_behavior, :default => true
 
   class MixpanelError < StandardError
   end
@@ -29,6 +31,7 @@ class Fluent::MixpanelOutput < Fluent::BufferedOutput
     @event_map_tag = conf['event_map_tag']
     @api_key = conf['api_key']
     @use_import = conf['use_import']
+    @use_legacy_prefix_behavior = conf['use_legacy_prefix_behavior']
 
     if @event_key.nil? and !@event_map_tag
       raise Fluent::ConfigError, "'event_key' must be specifed when event_map_tag == false."
@@ -58,6 +61,7 @@ class Fluent::MixpanelOutput < Fluent::BufferedOutput
       prop.delete('token')
 
       if @event_map_tag
+        tag.gsub!(/^\./, '') if @use_legacy_prefix_behavior
         data['event'] = tag
       elsif record[@event_key]
         data['event'] = record[@event_key]

--- a/test/plugin/test_out_mixpanel.rb
+++ b/test/plugin/test_out_mixpanel.rb
@@ -15,6 +15,7 @@ class MixpanelOutputTest < Test::Unit::TestCase
 
   IMPORT_CONFIG = CONFIG + %[ api_key test_api_key
                               use_import true
+                              use_legacy_prefix_behavior false
                             ]
 
   def create_driver(conf = CONFIG)
@@ -148,6 +149,20 @@ class MixpanelOutputTest < Test::Unit::TestCase
     assert_equal "value2",  @out[0]['properties']['key2']
   end
 
+  def test_write_with_event_map_tag_removing_prefix_LEGACY
+    stub_mixpanel
+    d = create_driver(CONFIG + "remove_tag_prefix mixpanel\n event_map_tag true\n use_legacy_prefix_behavior true")
+    time = Time.new('2014-01-01T01:23:45+00:00')
+    d.emit(sample_record, time)
+    d.run
+
+    assert_equal "123",     @out[0]['properties']['distinct_id']
+    assert_equal "test",    @out[0]['event']
+    assert_equal time.to_i, @out[0]['properties']['time']
+    assert_equal "value1",  @out[0]['properties']['key1']
+    assert_equal "value2",  @out[0]['properties']['key2']
+  end
+
   def test_write_with_event_map_tag_removing_suffix
     stub_mixpanel
     d = create_driver(CONFIG + "remove_tag_suffix .test\n event_map_tag true")
@@ -162,7 +177,7 @@ class MixpanelOutputTest < Test::Unit::TestCase
     assert_equal "value2",  @out[0]['properties']['key2']
   end
 
-    def test_write_with_event_map_tag_adding_prefix
+  def test_write_with_event_map_tag_adding_prefix
     stub_mixpanel
     d = create_driver(CONFIG + "add_tag_prefix foo.\n event_map_tag true")
     time = Time.new('2014-01-01T01:23:45+00:00')

--- a/test/plugin/test_out_mixpanel.rb
+++ b/test/plugin/test_out_mixpanel.rb
@@ -57,16 +57,6 @@ class MixpanelOutputTest < Test::Unit::TestCase
     assert_equal 'ip', d.instance.ip_key
   end
 
-  def test_configure_with_event_map_tag
-    d = create_driver(CONFIG + "remove_tag_prefix mixpanel\n event_map_tag true")
-
-    assert_equal 'test_token', d.instance.project_token
-    assert_equal 'user_id', d.instance.distinct_id_key
-    assert_equal nil, d.instance.event_key
-    assert_equal 'mixpanel', d.instance.remove_tag_prefix
-    assert_equal true.to_s, d.instance.event_map_tag
-  end
-
   def test_write
     stub_mixpanel
     d = create_driver(CONFIG + "event_key event")
@@ -121,21 +111,7 @@ class MixpanelOutputTest < Test::Unit::TestCase
     assert_equal "value2",      @out[0]['properties']['key2']
   end
 
-  def test_write_with_event_map_tag
-    stub_mixpanel
-    d = create_driver(CONFIG + "remove_tag_prefix mixpanel\n event_map_tag true")
-    time = Time.new('2014-01-01T01:23:45+00:00')
-    d.emit(sample_record, time)
-    d.run
-
-    assert_equal "123",     @out[0]['properties']['distinct_id']
-    assert_equal "test",    @out[0]['event']
-    assert_equal time.to_i, @out[0]['properties']['time']
-    assert_equal "value1",  @out[0]['properties']['key1']
-    assert_equal "value2",  @out[0]['properties']['key2']
-  end
-
-  def test_write_with_no_remove_tag_prefix
+  def test_write_with_no_tag_manipulation
     stub_mixpanel
     d = create_driver(CONFIG + "event_map_tag true")
     time = Time.new('2014-01-01T01:23:45+00:00')
@@ -148,6 +124,64 @@ class MixpanelOutputTest < Test::Unit::TestCase
     assert_equal "value1",        @out[0]['properties']['key1']
     assert_equal "value2",        @out[0]['properties']['key2']
   end
+
+  def test_write_with_event_map_tag_removing_prefix
+    stub_mixpanel
+    d = create_driver(CONFIG + "remove_tag_prefix mixpanel.\n event_map_tag true")
+    time = Time.new('2014-01-01T01:23:45+00:00')
+    d.emit(sample_record, time)
+    d.run
+
+    assert_equal "123",     @out[0]['properties']['distinct_id']
+    assert_equal "test",    @out[0]['event']
+    assert_equal time.to_i, @out[0]['properties']['time']
+    assert_equal "value1",  @out[0]['properties']['key1']
+    assert_equal "value2",  @out[0]['properties']['key2']
+  end
+
+  def test_write_with_event_map_tag_removing_suffix
+    stub_mixpanel
+    d = create_driver(CONFIG + "remove_tag_suffix .test\n event_map_tag true")
+    time = Time.new('2014-01-01T01:23:45+00:00')
+    d.emit(sample_record, time)
+    d.run
+
+    assert_equal "123",     @out[0]['properties']['distinct_id']
+    assert_equal "mixpanel",    @out[0]['event']
+    assert_equal time.to_i, @out[0]['properties']['time']
+    assert_equal "value1",  @out[0]['properties']['key1']
+    assert_equal "value2",  @out[0]['properties']['key2']
+  end
+
+    def test_write_with_event_map_tag_adding_prefix
+    stub_mixpanel
+    d = create_driver(CONFIG + "add_tag_prefix foo.\n event_map_tag true")
+    time = Time.new('2014-01-01T01:23:45+00:00')
+    d.emit(sample_record, time)
+    d.run
+
+    assert_equal "123",     @out[0]['properties']['distinct_id']
+    assert_equal "foo.mixpanel.test",    @out[0]['event']
+    assert_equal time.to_i, @out[0]['properties']['time']
+    assert_equal "value1",  @out[0]['properties']['key1']
+    assert_equal "value2",  @out[0]['properties']['key2']
+  end
+
+  def test_write_with_event_map_tag_adding_suffix
+    stub_mixpanel
+    d = create_driver(CONFIG + "add_tag_suffix .foo\n event_map_tag true")
+    time = Time.new('2014-01-01T01:23:45+00:00')
+    d.emit(sample_record, time)
+    d.run
+
+    assert_equal "123",     @out[0]['properties']['distinct_id']
+    assert_equal "mixpanel.test.foo",    @out[0]['event']
+    assert_equal time.to_i, @out[0]['properties']['time']
+    assert_equal "value1",  @out[0]['properties']['key1']
+    assert_equal "value2",  @out[0]['properties']['key2']
+  end
+
+
 
   def test_write_ignore_special_event
     stub_mixpanel

--- a/test/plugin/test_out_mixpanel.rb
+++ b/test/plugin/test_out_mixpanel.rb
@@ -57,6 +57,15 @@ class MixpanelOutputTest < Test::Unit::TestCase
     assert_equal 'ip', d.instance.ip_key
   end
 
+  def test_configure_with_event_map_tag
+    d = create_driver(CONFIG + "event_map_tag true")
+
+    assert_equal 'test_token', d.instance.project_token
+    assert_equal 'user_id', d.instance.distinct_id_key
+    assert_equal nil, d.instance.event_key
+    assert_equal true.to_s, d.instance.event_map_tag
+  end
+
   def test_write
     stub_mixpanel
     d = create_driver(CONFIG + "event_key event")

--- a/test/plugin/test_out_mixpanel.rb
+++ b/test/plugin/test_out_mixpanel.rb
@@ -163,6 +163,20 @@ class MixpanelOutputTest < Test::Unit::TestCase
     assert_equal "value2",  @out[0]['properties']['key2']
   end
 
+  def test_write_with_event_map_tag_removing_prefix_LEGACY_with_dot
+    stub_mixpanel
+    d = create_driver(CONFIG + "remove_tag_prefix mixpanel.\n event_map_tag true\n use_legacy_prefix_behavior true")
+    time = Time.new('2014-01-01T01:23:45+00:00')
+    d.emit(sample_record, time)
+    d.run
+
+    assert_equal "123",     @out[0]['properties']['distinct_id']
+    assert_equal "test",    @out[0]['event']
+    assert_equal time.to_i, @out[0]['properties']['time']
+    assert_equal "value1",  @out[0]['properties']['key1']
+    assert_equal "value2",  @out[0]['properties']['key2']
+  end
+
   def test_write_with_event_map_tag_removing_suffix
     stub_mixpanel
     d = create_driver(CONFIG + "remove_tag_suffix .test\n event_map_tag true")


### PR DESCRIPTION
Use the HandleTagNameMixin provided by fluent rather than rolling our own. This doesn't break current behavior but adds the ability to add and remove suffixs and prefixs. I added tests for all.