### PR TITLE
respect time if it's passed in, set it if not

### DIFF
--- a/lib/fluent/plugin/out_mixpanel.rb
+++ b/lib/fluent/plugin/out_mixpanel.rb
@@ -88,7 +88,7 @@ class Fluent::MixpanelOutput < Fluent::BufferedOutput
       end
 
       prop.select! {|key, _| !key.start_with?('mp_') }
-      prop.merge!('time' => time.to_i)
+      prop['time'] = (data['time'] || time.to_i)
 
       records << data
     end


### PR DESCRIPTION
If time is sent as part of the data payload, use it as the timestamp, don't override it. 