### PR TITLE
Support secret parameters

### DIFF
--- a/lib/fluent/plugin/out_mixpanel.rb
+++ b/lib/fluent/plugin/out_mixpanel.rb
@@ -4,8 +4,8 @@ class Fluent::MixpanelOutput < Fluent::BufferedOutput
 
   include Fluent::HandleTagNameMixin
 
-  config_param :project_token, :string
-  config_param :api_key, :string, :default => ''
+  config_param :project_token, :string, :secret => true
+  config_param :api_key, :string, :default => '', :secret => true
   config_param :use_import, :bool, :default => nil
   config_param :distinct_id_key, :string
   config_param :event_key, :string, :default => nil


### PR DESCRIPTION
Fluentd 0.12.13 or later supports secret parameters feature.
This feature works as below:

```log
  <match output.mixpanel.*>
    type mixpanel
    project_token xxxxxx
    distinct_id_key user_id
    event_key event_name
  </match>
</ROOT>
```

I think that `project_token` and `api_key` contains sensitive information.
If there is any problems, please let me know.