### PR TITLE
Error handling discard event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.idea/

--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ tracker.track("123", "event1", { key1: "value1", key2: "value2" })
 
 You can use tag name as event name like this. (see additional tag manipulations options below)
 
+#### Discarding mixpanel errors
+
+When delivering events to Mixpanel, Fluent creates a chunk of messages to send. By default, if one event fails to send to Mixpanel, all messages in that chunk are requeued for delivery. Enabling `discard_event_on_send_error` allows you to ignore single delivery failures. The event is logged via `info`, including the record being dropped.
+
+```
+<match output.mixpanel.*>
+  ...
+  discard_event_on_send_error true
+  ...
+</match>
+```
+
 ##PLEASE NOTE (breaking api change in a future release)
 
 The api for remove_tag_prefix will be changing in a future release. There is currently a boolean option,

--- a/fluent-plugin-mixpanel.gemspec
+++ b/fluent-plugin-mixpanel.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "fluentd", ">= 0.10.55"
-  spec.add_runtime_dependency "mixpanel-ruby", "~> 2.1.0"
+  spec.add_runtime_dependency "mixpanel-ruby", "~> 2.2.0"
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "webmock"

--- a/lib/fluent/plugin/mixpanel_ruby_error_handler.rb
+++ b/lib/fluent/plugin/mixpanel_ruby_error_handler.rb
@@ -10,6 +10,6 @@ class Fluent::MixpanelOutputErrorHandler < Mixpanel::ErrorHandler
      # true/false. If there is an error, an optional error handler is called.
      # In this case, here, we only want to log the error for future development
      # of error handling.
-     @logger.error "MixpanelOutputErrorHandler:\n\tClass: #{error.class.to_s}\n\t#{error.inspect}\n\tBacktrace: #{error.backtrace}"
+     @logger.error "MixpanelOutputErrorHandler:\n\tClass: #{error.class.to_s}\n\tMessage: #{error.message}\n\tBacktrace: #{error.backtrace}"
    end
 end

--- a/lib/fluent/plugin/mixpanel_ruby_error_handler.rb
+++ b/lib/fluent/plugin/mixpanel_ruby_error_handler.rb
@@ -1,0 +1,15 @@
+require 'mixpanel-ruby'
+
+class Fluent::MixpanelOutputErrorHandler < Mixpanel::ErrorHandler
+   def initialize(logger)
+     @logger = logger
+   end
+
+   def handle(error)
+     # Default behavior is to not return an error. Mixpanel-ruby gem returns
+     # true/false. If there is an error, an optional error handler is called.
+     # In this case, here, we only want to log the error for future development
+     # of error handling.
+     @logger.error "MixpanelOutputErrorHandler:\n\tClass: #{error.class.to_s}\n\t#{error.inspect}\n\tBacktrace: #{error.backtrace}"
+   end
+end

--- a/lib/fluent/plugin/out_mixpanel.rb
+++ b/lib/fluent/plugin/out_mixpanel.rb
@@ -14,6 +14,7 @@ class Fluent::MixpanelOutput < Fluent::BufferedOutput
   config_param :event_map_tag, :bool, :default => false
   #NOTE: This will be removed in a future release. Please specify the '.' on any prefix
   config_param :use_legacy_prefix_behavior, :default => true
+  config_param :discard_event_on_send_error, :default => false
 
   class MixpanelError < StandardError
   end
@@ -33,6 +34,7 @@ class Fluent::MixpanelOutput < Fluent::BufferedOutput
     @api_key = conf['api_key']
     @use_import = conf['use_import']
     @use_legacy_prefix_behavior = conf['use_legacy_prefix_behavior']
+    @discard_event_on_send_error = conf['discard_event_on_send_error']
 
     if @event_key.nil? and !@event_map_tag
       raise Fluent::ConfigError, "'event_key' must be specifed when event_map_tag == false."
@@ -111,13 +113,15 @@ class Fluent::MixpanelOutput < Fluent::BufferedOutput
         success = @tracker.track(record['distinct_id'], record['event'], record['properties'])
       end
 
-      raise MixpanelError.new("Failed to track event to mixpanel") unless success
-
-      # unless success
-      #   msg = "Failed to track event to mixpanel:\n"
-      #   msg += "\tRecord: #{record.to_json}"
-      #   log.info(msg)
-      # end
+      unless success
+        if @discard_event_on_send_error
+          msg = "Failed to track event to mixpanel:\n"
+          msg += "\tRecord: #{record.to_json}"
+          log.info(msg)
+        else
+          raise MixpanelError.new("Failed to track event to mixpanel")
+        end
+      end
     end
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -31,6 +31,7 @@ def unused_port
   port
 end
 
+require 'fluent/plugin/mixpanel_ruby_error_handler'
 require 'fluent/plugin/out_mixpanel'
 require 'fluent/plugin/in_http_mixpanel'
 

--- a/test/plugin/test_mixpanel_ruby_error_handler.rb
+++ b/test/plugin/test_mixpanel_ruby_error_handler.rb
@@ -1,0 +1,16 @@
+require 'helper'
+
+class MixpanelRubyErrorHandlerTest < Test::Unit::TestCase
+
+  def test_handle
+    mixpanel_error = Fluent::MixpanelOutput::MixpanelError.new("Foobar failed")
+    @io = StringIO.new
+    logger = Logger.new(@io)
+    error = Fluent::MixpanelOutputErrorHandler.new(logger)
+    error.handle(mixpanel_error)
+
+    output = @io.string
+    expected_output = "MixpanelOutputErrorHandler:\n\tClass: Fluent::MixpanelOutput::MixpanelError\n\tMessage: Foobar failed\n\tBacktrace: \n"
+    assert_match expected_output, output
+  end
+end

--- a/test/plugin/test_out_mixpanel.rb
+++ b/test/plugin/test_out_mixpanel.rb
@@ -366,6 +366,6 @@ class MixpanelOutputTest < Test::Unit::TestCase
     assert_match "Message: Could not write to Mixpanel, server responded with 503 returning: 'Service Unavailable", logs[0]
     assert_match "Backtrace", logs[0]
     assert_match "Failed to track event to mixpanel", logs[1]
-    assert_match 'Record: {"properties":{"key1":"value1","key2":"value2","time":1388552400},"event":"event1","distinct_id":"123"}', logs[1]
+    assert_match 'Record: {"properties":{"key1":"value1","key2":"value2","time":' + time.to_s + '},"event":"event1","distinct_id":"123"}', logs[1]
   end
 end


### PR DESCRIPTION
This PR:

1. updated to current master as of 2016-09-22 (all other PRs, as of now, have been merged)
1. updates the mixpanel-ruby gem to 2.2.0, which allows for custom error handling
1. implements custom error handling, so that the user is able to gather more information about what happened between the mixpanel-ruby gem and Mixpanel
1. gives the user the option to discard records when there is an error sending to Mixpanel so that the entire chunk of messages is not requeued, causing duplicate data on Mixpanel
