### PR TITLE
Convert to support 0.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/hakobera/fluent-plugin-mixpanel.png?branch=master)](https://travis-ci.org/hakobera/fluent-plugin-mixpanel)
 
-**CAUTION** This plugin does not support Ruby < 2.0, and fluentd >= 0.14.
+**CAUTION** This plugin does not support Ruby < 2.0
 
 ## Component
 

--- a/fluent-plugin-mixpanel.gemspec
+++ b/fluent-plugin-mixpanel.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-mixpanel"
-  spec.version       = "0.1.0"
+  spec.version       = "0.2.0"
   spec.authors       = ["Kazuyuki Honda"]
   spec.email         = ["hakobera@gmail.com"]
   spec.summary       = %q{Fluentd plugin to input/output event track data to mixpanel}
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0.0'
 
-  spec.add_dependency "fluentd", [">= 0.10.58", "< 0.14.0"]
+  spec.add_dependency "fluentd", [">= 0.14.0"]
   spec.add_dependency "mixpanel-ruby", "~> 2.2.0"
 
   spec.add_development_dependency "rake"

--- a/lib/fluent/plugin/in_http_mixpanel.rb
+++ b/lib/fluent/plugin/in_http_mixpanel.rb
@@ -1,10 +1,15 @@
 require 'fluent/plugin/in_http'
 require 'base64'
 
-class Fluent::HttpMixpanelInput < Fluent::HttpInput
+class Fluent::HttpMixpanelInput < Fluent::Plugin::HttpInput
   Fluent::Plugin.register_input('http_mixpanel', self)
 
   config_param :tag_prefix, :default => 'mixpanel'
+
+  def configure(conf)
+    compat_parameters_convert(conf, :inject, :extract, :parser, :formatter, default_chunk_key: "")
+    super
+  end
 
   def on_request(path_info, params)
     data = Base64.decode64(params['data']).force_encoding('utf-8')

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,5 +1,5 @@
-require 'rubygems'
-require 'bundler'
+require "bundler/setup"
+require "test/unit"
 begin
   Bundler.setup(:default, :development)
 rescue Bundler::BundlerError => e
@@ -11,15 +11,7 @@ require 'test/unit'
 require 'webmock/test_unit'
 WebMock.disable_net_connect!(:allow_localhost => true)
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
-$LOAD_PATH.unshift(File.dirname(__FILE__))
+$LOAD_PATH.unshift(File.join(__dir__, "..", "lib"))
+$LOAD_PATH.unshift(__dir__)
+
 require 'fluent/test'
-unless ENV.has_key?('VERBOSE')
-  nulllogger = Object.new
-  nulllogger.instance_eval {|obj|
-    def method_missing(method, *args)
-      # pass
-    end
-  }
-  $log = nulllogger
-end

--- a/test/plugin/test_in_http_mixpanel.rb
+++ b/test/plugin/test_in_http_mixpanel.rb
@@ -1,10 +1,14 @@
 require 'helper'
 require 'net/http'
+require 'cgi'
 require 'base64'
 require 'fluent/test'
+require 'fluent/test/helpers'
 require 'net/http'
 require 'serverengine'
 require 'fluent/plugin/in_http_mixpanel'
+
+include Fluent::Test::Helpers
 
 class HttpMixpanelInputTest < Test::Unit::TestCase
 
@@ -118,10 +122,13 @@ class HttpMixpanelInputTest < Test::Unit::TestCase
 
   def track(tag, params)
     event = tag.sub(/^mixpanel\.(.+)$/, '\1')
-    params['json']['time'] = params['time'] if params['time']
+    # DO NOT modify the original json; doing so changes what is expected to be emitted
+    # and causes the tests to fail
+    json = params['json'].dup
+    json['time'] = params['time'] if params['time']
     data = {
       event: event,
-      properties: params['json']
+      properties: json
     }
     data = CGI.escape(Base64.encode64(data.to_json))
     query = "data=#{data}"


### PR DESCRIPTION
This is a crude, but seemingly effective, conversion to support 0.14.0.  Mostly just updating the tests, and I'm a little unsure about some of them, so it warrants careful review by someone more familiar with the codebase.