### PR TITLE
Add batching support for sending events to mixpanel, for throughput

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ add_tag_prefix <tag_prefix_to_add_including_the_dot>
 add_tag_suffix <tag_suffix_to_add_including_the_dot>
 ```
 
+#### Batch calls to mixpanel
+
+With 'batch\_to\_mixpanel' set to 'true' (default is false, for consistency with previous versions), events are sent in batches to MixPanel, rather than one per HTTP request.  This can increase throughput by an order of magnitude or more (depending on latency and other overhead)
+
 ### HttpMixpanelInput
 
 HttpMixpanelInput has same configuration as [http Input Plugin](http://docs.fluentd.org/en/articles/in_http).


### PR DESCRIPTION
A small patch to use batching when sending to mixpanel.  As noted in the README, this has a substantial effect on throughput.  In my testing (from NZ with at least 130ms latency to api.mixpanel.com) this increased throughput by a factor of 20-25 (with multi-threading in 0.14.0).  For big bursts of events, this reduces the number of API calls to mixpanel significantly.

NB:  Tests will need changing if/when you land the 0.14 upgrade PR I submitted earlier; if you want to land that first, then this one, let me know and I'll update this PR.